### PR TITLE
fix: add undefined check, add svg2 syntax support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,10 +7,10 @@ var parser = document.createElement('a');
  * @return {Object}                Object with sorted use elements
  */
 function sortItems(items, element) {
-	var xlink = element.getAttribute('xlink:href');
+	var xlink = element.getAttribute('xlink:href') || element.getAttribute('href');
 
-	// return if xlink just contains fragment
-	if (xlink[0] === '#') {
+	// return if no href attribute present or just contains fragment
+	if (!xlink || xlink[0] === '#') {
 		return items;
 	}
 


### PR DESCRIPTION
The use of `<use href="">` without `xlink:` prefix (svg2 spec) causes a JavaScript undefined error in the polyfill. See also: https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xlink:href